### PR TITLE
Add template icon for resources in serch results.

### DIFF
--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -159,20 +159,22 @@ class modSearchProcessor extends modProcessor
         }
 
         $c = $this->modx->newQuery('modResource');
+        $c->leftJoin('modTemplate','modTemplate','modResource.template=modTemplate.id');
+        $c->select($this->modx->getSelectColumns('modResource','modResource').", modTemplate.icon as icon");
         $c->where(array(
             array(
-                'pagetitle:LIKE' => '%' . $this->query .'%',
-                'OR:longtitle:LIKE' => '%' . $this->query .'%',
-                'OR:alias:LIKE' => '%' . $this->query .'%',
-                'OR:description:LIKE' => '%' . $this->query .'%',
-                'OR:introtext:LIKE' => '%' . $this->query .'%',
-                'OR:id:=' => $this->query,
+                'modResource.pagetitle:LIKE' => '%' . $this->query .'%',
+                'OR:modResource.longtitle:LIKE' => '%' . $this->query .'%',
+                'OR:modResource.alias:LIKE' => '%' . $this->query .'%',
+                'OR:modResource.description:LIKE' => '%' . $this->query .'%',
+                'OR:modResource.introtext:LIKE' => '%' . $this->query .'%',
+                'OR:modResource.id:=' => $this->query,
             ),
             array(
-                'context_key:IN' => $contextKeys,
+                'modResource.context_key:IN' => $contextKeys,
             )
         ));
-        $c->sortby('createdon', 'DESC');
+        $c->sortby('modResource.createdon', 'DESC');
 
         $c->limit($this->maxResults);
 
@@ -186,6 +188,7 @@ class modSearchProcessor extends modProcessor
                 'type' => $type,
                 'class' => $record->get('class_key'),
                 'type_label' => $typeLabel,
+                'icon' => $record->get('icon')?(str_replace('icon-','',$record->get('icon'))):false,
             );
         }
     }


### PR DESCRIPTION
### What does it do?
Add template icon for resources in uberbar serch results.

### Why is it needed?
If we have some resources with same names, but different templates, in search results we see its icons to distinguish them.

### Related issue(s)/PR(s)
![result](https://i.imgur.com/nD3y7kk.png "Result")
